### PR TITLE
CLI-368 Unified CLI never receives connect event from Java app for socket interactive mode

### DIFF
--- a/appc-inquirer.js
+++ b/appc-inquirer.js
@@ -33,17 +33,19 @@ SocketPrompt.prototype.prompt = function(questions, callback) {
 	questions = !Array.isArray(questions) ? [questions] : questions;
 
 	var self = this;
-	var client = net.connect({ 
-		host: this.host,
-		port: this.port 
-	});
+	var client = new net.Socket();
 
 	async.waterfall([
 
 		// set up handlers for socket
 		function(cb) {
-			client.on('error', callback);
 			client.on('connect', cb);
+			client.on('error', callback);
+
+			client.connect({
+				host: self.host,
+				port: self.port
+			});
 		},
 
 		// send question, receive answer


### PR DESCRIPTION
When appc CLI attempts to make a connection to either Node server or netcat, it always receives the 'connect' event. However, if the server in this case is Java/Studio, then even after the socket connection is made successfully, appc CLI never receives the 'connect' event.

We are currently making a connection to the server, and only then adding up the event listeners for the client. I believe this could be a timing issue with Server and client connection - the appc CLI might be receiving 'connect' event before it actually adds up a event listener for 'connect' event.

The fix here is to add the event listeners before we actually attempt to make the socket connection.