### PR TITLE
[CLI-1143] Make inquirer return default answers again

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 coverage
 cover
+build.log

--- a/appc-inquirer.js
+++ b/appc-inquirer.js
@@ -4,7 +4,7 @@ var async = require('async'),
 
 module.exports = new AppcInquirer();
 
-function AppcInquirer() {};
+function AppcInquirer() {}
 
 AppcInquirer.prototype.prompt = function prompt(questions, opts, callback) {
 	callback = arguments[arguments.length-1];
@@ -17,11 +17,19 @@ AppcInquirer.prototype.prompt = function prompt(questions, opts, callback) {
 
 	// have inquirer handle questions via stdio
 	else {
-		return inquirer.prompt(questions).then(function(answers) {
-			return callback(null, answers);
+		var promise = inquirer.prompt(questions);
+		promise.then(function(answers) {
+			// inquirer filters answers from the parameter for questions that where
+			// not actually asked due to ther when function returning false. But we
+			// can still get the unfiltered answers directly from the ui reference
+			// set on the promise.
+			return callback(null, promise.ui.answers);
+		}).catch(function(error) {
+			return callback(error);
 		});
+		return promise.ui;
 	}
-}
+};
 
 function SocketPrompt(opts) {
 	this.host = opts.host || '127.0.0.1';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "appc-inquirer",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "node.js prompt module for asking the same questions different ways",
   "main": "appc-inquirer.js",
   "files": [


### PR DESCRIPTION
JIRA: https://jira.appcelerator.org/browse/CLI-1143

We often add default values for answers inside the "when" function of a
question and then return false. Inquirer will not return those answers
since 1.0.0 as it means they were skipped entirely. To workaround this
we can get our injected default values from the prompt UI reference
that's attached to the promise and holds the answers before they where
filtered by inquirer.